### PR TITLE
feat: auto-configure project path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Download the repository as `.zip` file and extract it or clone it to your comput
 To use this Add-on, several 3rd party libraries are required (see `requirements.txt`). You can either install the dependencies to
 the Blender python or if python is already installed on the system and the python version is compatible with the Blender python version you can also install the dependencies on your system.
 3. Adding the Project to the Python path:
-Open `automask.py` in your favorite text editor and replace `PYTHON_PATH` with the path to you python site-packages if needed and `PROJECT_DIR` with the path to the directory you downloaded this repository to.
+The add-on automatically adds its own directory to Python's module search path. To include additional site-packages, set the `PYTHON_PATH` environment variable before launching Blender.
 4. Install Dependencies:
 * PyTorch 
 The neural network that does the heavy lifting is written for [PyTorch](https://pytorch.org/).

--- a/automask.py
+++ b/automask.py
@@ -1,15 +1,21 @@
 
 from __future__ import print_function
+import os
 import bpy
 from bpy.types import Operator, Panel, PropertyGroup, WindowManager
 from bpy.props import PointerProperty, StringProperty, IntProperty, FloatProperty, BoolProperty
 import sys
-paths = [
-    #PYTHON_PATH,
-    PROJECT_DIR 
-]
+from pathlib import Path
+
+# Determine optional Python package path and project directory automatically
+PYTHON_PATH = os.environ.get("PYTHON_PATH")
+PROJECT_DIR = Path(__file__).resolve().parent
+
+paths = [p for p in (PYTHON_PATH, str(PROJECT_DIR)) if p]
 for p in paths:
-    sys.path.insert(0, p)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
 from mask_spline import *
 from SiamMask import *
 


### PR DESCRIPTION
## Summary
- determine AutoMask's project directory at runtime
- optionally honor `PYTHON_PATH` env var
- document automatic path setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ae8a6c96d88332a6bc344629622cd9